### PR TITLE
cross-platform support

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,5 @@
+const opener = require("opener");
 const request = require("request-promise");
-const exec = require("child_process").execSync;
 
 const SFSPCA_BASE = "https://www.sfspca.org"
 const ADOPTION_PAGE = `${SFSPCA_BASE}/adoptions/cats`;
@@ -44,5 +44,5 @@ request.get(ADOPTION_PAGE)
     });
     console.log(`The fattest cat is ${fattestCat.name}. ${(fattestCat.isFemale ? "She" : "He")} weighs ${fattestCat.lbs} lbs and ${fattestCat.oz} oz.`);
     setTimeout(() => console.log("Opening cat profile..."), 2000);
-    setTimeout(() => exec(`open ${fattestCat.url}`), 4000);
+    setTimeout(() => opener(fattestCat.url), 4000);
   });

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "opener": "^1.4.3",
     "request": "^2.79.0",
     "request-promise": "^4.1.1"
   },


### PR DESCRIPTION
`open` is only available on OSX. This makes `fattest-cat` work on both Windows and Linux. Presumably. I'm pretty sure.