### PR TITLE
Add repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "1.0.0",
   "description": "",
   "main": "index.js",
+  "repository": "lexiross/fattest-cat",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },


### PR DESCRIPTION
npm likes warning about this, and the npm website actually uses this field to help point users straight at the right git repo! so let's just shove it in or whatever.