### PR TITLE
Add support for nth fattest cat

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
     "colors": "^1.1.2",
     "express": "^4.15.3",
     "lodash": "^4.17.4",
+    "number-to-words": "^1.2.3",
     "opener": "^1.4.3",
     "request": "^2.79.0",
     "request-promise": "^4.1.1"


### PR DESCRIPTION
Currently, only the fattest cat is visible. After you determine which cat is the fattest cat, it may be desirable to see the second, third or fourth fattest cat.
- [ ] Adds support for finding the `n`th fattest cat
- [ ] Adds clear printing of which of `n` fattest cats you've requested